### PR TITLE
Fixed loading file with multiple animations

### DIFF
--- a/import_gta_ifp.py
+++ b/import_gta_ifp.py
@@ -114,7 +114,11 @@ def load(context, filepath, *, fps, global_matrix):
     for anim in ifp.data.animations:
         act, mb = create_action(arm_obj, anim, fps, global_matrix)
         act.name = anim.name
-        animation_data.action = act
+
+        track = animation_data.nla_tracks.new()
+        track.name = anim.name
+        track.strips.new(name=anim.name, start=1, action=act)
+
         missing_bones = missing_bones.union(mb)
 
     if missing_bones:

--- a/import_gta_ifp.py
+++ b/import_gta_ifp.py
@@ -117,7 +117,7 @@ def load(context, filepath, *, fps, global_matrix):
 
         track = animation_data.nla_tracks.new()
         track.name = anim.name
-        track.strips.new(name=anim.name, start=1, action=act)
+        track.strips.new(name=anim.name, start=0, action=act)
 
         missing_bones = missing_bones.union(mb)
 


### PR DESCRIPTION
Fixed loading .ifp file with multiple animations.
(For example: `countn2.ifp` from GTA San Andreas which contains world's animations for multiple objects)
Currently only one track is used and overrides itself with each new animation, Instead the new NLA track is need to be created for each animation.